### PR TITLE
Layout Shift 방지 스타일 변경, react-slick 사용 컴포넌트에 lazyLoad 옵션 추가

### DIFF
--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef, useState } from "react";
+
+import { AiOutlineRight, AiOutlineLeft } from "../assets/Icons";
+import * as S from "../styles/VideoPost/Slider.styles";
+
+type SliderProps = {
+	children?: React.ReactNode;
+	showArrows?: boolean | undefined;
+	className?: string | undefined;
+	width?: number;
+	height?: number;
+	slidesToShow?: number | undefined;
+};
+
+const Slider = ({
+	children, // children에 slider에 들어갈 요소들 list 받기
+	showArrows = true, // 화살표 보이게/안보이게
+	slidesToShow = 1, // 슬라이더 뷰에 한번에 몇 개 보일지
+	className,
+	width,
+	height,
+}: SliderProps) => {
+	const [currIndex, setCurrIndex] = useState<number>(0);
+	const sliderRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (sliderRef.current !== null) {
+			sliderRef.current.style.transform = `translateX(-${currIndex}00%)`;
+		}
+	}, [currIndex]);
+
+	// handlers
+	const sliderPrev = () => {
+		setCurrIndex((prev) => prev - 1);
+	};
+	const sliderNext = () => {
+		setCurrIndex((prev) => prev + 1);
+	};
+
+	return (
+		<S.SliderContainer>
+			<S.ArrowButton direction="left" onClick={sliderPrev}>
+				<AiOutlineLeft />
+			</S.ArrowButton>
+			<S.ArrowButton direction="right" onClick={sliderNext}>
+				<AiOutlineRight />
+			</S.ArrowButton>
+			<div ref={sliderRef}>{children}</div>
+		</S.SliderContainer>
+	);
+};
+
+export default Slider;

--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -45,7 +45,7 @@ const Slider = ({
 			<S.ArrowButton direction="right" onClick={sliderNext}>
 				<AiOutlineRight />
 			</S.ArrowButton>
-			<div ref={sliderRef}>{children}</div>
+			<S.Slider ref={sliderRef}>{children}</S.Slider>
 		</S.SliderContainer>
 	);
 };

--- a/src/components/TestComponent.tsx
+++ b/src/components/TestComponent.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+import { useRecoilState } from "recoil";
+
+import PlaceDetail from "./VideoPost/PlaceDetail";
+
+import Slider from "./Slider";
+import { mockPlaceData } from "./VideoPost/mockData";
+import useResponsive from "../hooks/useResponsive";
+import { placeDetailSliderIdx } from "../recoil";
+
+const TestComponent = () => {
+	// const { isMobile } = useResponsive();
+
+	// const sliderRef = useRef<Slider>(null);
+	const [idx, setIdx] = useRecoilState(placeDetailSliderIdx);
+	const settings = {
+		showArrows: true,
+		slidesToShow: 1,
+	};
+
+	// useEffect(() => {
+	// 	sliderRef.current?.slickGoTo(idx);
+	// }, [idx]);
+
+	// useEffect(() => {
+	// 	setIdx(0);
+	// }, [sliderRef.current]);
+
+	return (
+		<Slider {...settings}>
+			{/* <Slider ref={sliderRef} {...settings}> */}
+			{mockPlaceData.map((place, idx) => {
+				// if (sliderRef.current) {
+				return (
+					<PlaceDetail
+						key={idx}
+						id={idx}
+						onNextClick={() => {}}
+						onPrevClick={() => {}}
+					/>
+				);
+				// }
+			})}
+		</Slider>
+	);
+};
+
+export default TestComponent;

--- a/src/components/VideoPost/PhotosSlider.tsx
+++ b/src/components/VideoPost/PhotosSlider.tsx
@@ -22,7 +22,7 @@ function VideoPostPhotoSlider({ photoLength, id }: PhotoSliderProps) {
 	const setModalState = useSetRecoilState(modalState);
 	const settings: Settings = {
 		dots: false,
-		lazyLoad: "anticipated",
+		lazyLoad: "ondemand",
 		infinite: true,
 		speed: 500,
 		swipeToSlide: true,

--- a/src/components/VideoPost/PhotosSlider.tsx
+++ b/src/components/VideoPost/PhotosSlider.tsx
@@ -22,6 +22,7 @@ function VideoPostPhotoSlider({ photoLength, id }: PhotoSliderProps) {
 	const setModalState = useSetRecoilState(modalState);
 	const settings: Settings = {
 		dots: false,
+		lazyLoad: "anticipated",
 		infinite: true,
 		speed: 500,
 		swipeToSlide: true,

--- a/src/components/VideoPost/PlaceDetail.tsx
+++ b/src/components/VideoPost/PlaceDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useSetRecoilState, useRecoilState } from "recoil";
 
 import useResponsive from "../../hooks/useResponsive";
@@ -216,7 +216,9 @@ function VideoPostPlaceDetail({
 					<img src={`./rating.png`} />
 					<div className="textArea">
 						<S.ReviewCounts>
-							{mockPlaceData[id].rating.value}
+							<Suspense fallback={"loading"}>
+								{mockPlaceData[id].rating.value}
+							</Suspense>
 						</S.ReviewCounts>
 						<span>
 							<StarIcon />

--- a/src/components/VideoPost/Places.tsx
+++ b/src/components/VideoPost/Places.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { Suspense, useEffect, useRef } from "react";
 import Slider, { Settings } from "react-slick";
 import { useRecoilState } from "recoil";
 
@@ -16,6 +16,7 @@ function VideoPostPlaces() {
 	const [idx, setIdx] = useRecoilState(placeDetailSliderIdx);
 	const settings: Settings = {
 		dots: false,
+		lazyLoad: "ondemand",
 		speed: 500,
 		slidesToShow: 1,
 		slidesToScroll: 1,
@@ -36,12 +37,14 @@ function VideoPostPlaces() {
 			{mockPlaceData.map((place, idx) => {
 				if (sliderRef.current !== null) {
 					return (
-						<PlaceDetail
-							key={idx}
-							id={idx}
-							onNextClick={sliderRef.current.slickNext}
-							onPrevClick={sliderRef.current.slickPrev}
-						/>
+						<Suspense fallback={"loading..."}>
+							<PlaceDetail
+								key={idx}
+								id={idx}
+								onNextClick={sliderRef.current.slickNext}
+								onPrevClick={sliderRef.current.slickPrev}
+							/>
+						</Suspense>
 					);
 				}
 			})}

--- a/src/components/VideoPost/mobile/PhotoSlider.tsx
+++ b/src/components/VideoPost/mobile/PhotoSlider.tsx
@@ -17,7 +17,7 @@ function VideoMobilePhotoSlider({
 }: VideoMobilePhotoSliderProps) {
 	const settings: Settings = {
 		dots: true,
-		lazyLoad: "anticipated",
+		lazyLoad: "ondemand",
 		infinite: true,
 		slidesToShow: 1,
 		slidesToScroll: 1,

--- a/src/components/VideoPost/mobile/PhotoSlider.tsx
+++ b/src/components/VideoPost/mobile/PhotoSlider.tsx
@@ -17,6 +17,7 @@ function VideoMobilePhotoSlider({
 }: VideoMobilePhotoSliderProps) {
 	const settings: Settings = {
 		dots: true,
+		lazyLoad: "anticipated",
 		infinite: true,
 		slidesToShow: 1,
 		slidesToScroll: 1,

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,11 +1,16 @@
 import { createBrowserRouter } from "react-router-dom";
 
 import App from "./pages/App";
+import TestComponent from "./components/TestComponent";
 
 const router = createBrowserRouter([
 	{
-		path:'/',
-		element:<App />,
+		path: "/",
+		element: <App />,
+	},
+	{
+		path: "/test",
+		element: <TestComponent />,
 	},
 ]);
 

--- a/src/styles/VideoPost/PlaceDetailComponents.styles.ts
+++ b/src/styles/VideoPost/PlaceDetailComponents.styles.ts
@@ -70,7 +70,9 @@ export const PhotoStyledSliderChildren = styled.div`
 
 //PlaceDetail Review
 export const ReviewContainer = styled.div`
-	display: flex;
+	/* display: flex; */
+	display: grid;
+	grid-template-columns: 185px 1fr;
 	gap: 32px;
 	margin-bottom: 47px;
 	padding-left: 84px;

--- a/src/styles/VideoPost/Slider.styles.ts
+++ b/src/styles/VideoPost/Slider.styles.ts
@@ -7,6 +7,7 @@ export const SliderContainer = styled.div<{
 	position: relative;
 	width: ${({ width }) => (width ? width : "100%")};
 	height: ${({ height }) => (height ? height : "100%")};
+	transition: all 0.3s ease-in-out;
 `;
 
 export const ArrowButton = styled.button<{
@@ -14,6 +15,13 @@ export const ArrowButton = styled.button<{
 	showArrows?: boolean;
 }>`
 	position: fixed;
+	z-index: 10;
 	${({ direction }) =>
 		direction === "left" ? "left: 10px;" : "right: 10px;"}
+`;
+
+export const Slider = styled.div`
+	transition: all 0.3s ease-in-out;
+	display: flex;
+	flex-wrap: nowrap;
 `;

--- a/src/styles/VideoPost/Slider.styles.ts
+++ b/src/styles/VideoPost/Slider.styles.ts
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+export const SliderContainer = styled.div<{
+	width?: number;
+	height?: number;
+}>`
+	position: relative;
+	width: ${({ width }) => (width ? width : "100%")};
+	height: ${({ height }) => (height ? height : "100%")};
+`;
+
+export const ArrowButton = styled.button<{
+	direction?: string;
+	showArrows?: boolean;
+}>`
+	position: fixed;
+	${({ direction }) =>
+		direction === "left" ? "left: 10px;" : "right: 10px;"}
+`;


### PR DESCRIPTION
### 작업한 내용
- Slider 컴포넌트를 만들고 있으나 아직 미완성입니다. 
- 리뷰에서 사진이 로드될 때 Layout Shift가 발생하는 것을 발견하고 ReviewContainer 스타일을 변경했습니다.
- react-slick 슬라이더를 사용하는 컴포넌트에서 settings에 lazyLoad: "ondemand" 옵션을 추가했습니다. 다음 컴포넌트로 넘겼을 때 해당 컴포넌트가 로드되게끔 만듭니다.

### 중점적으로 봐 주었으면 하는 부분
- 미완성인 Slider 컴포넌트가 브랜치에 포함되어있는데 같이 merge 해도 될까요? 혹시 미완성 컴포넌트가 develope에 추가되는 것이 꺼려진다면 삭제해서 다시 commit 하겠습니다!

### 요청
- lazy load 옵션을 사용한 환경에서 성능 측정을 정확하게 해보면 좋겠습니다.
- 이 브랜치가 merge되었을 때 다시 배포환경에서 pagespeed를 돌려보면 어떨까요?
- `npm start`했을 때, `npm run build`해서 build 폴더에서 live server 열었을 때 각각 52점, 55점으로 측정되었습니다.(재 측정마다 점수가 조금씩 달라집니다.) 두 경우 모두 TBT 점수가 많이 올랐습니다.

[npm start]
<img width="500" alt="image" src="https://github.com/F-orever/planit-frontend/assets/102221305/53c0e82d-3e76-4fae-942e-823baa6f9c4d">

[build live server]
<img width="500" alt="image" src="https://github.com/F-orever/planit-frontend/assets/102221305/07274481-fa2c-4afb-bdc7-0739c6b63cfb">
